### PR TITLE
start looking at cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,6 @@ authors = ["m.kearney@unimelb.edu.au"]
 version = "0.1.0"
 
 [deps]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/Microclimate.jl
+++ b/src/Microclimate.jl
@@ -31,6 +31,11 @@ export MicroParams, MicroForcing
 
 export runmicro
 
+@compound H2O
+@compound O2
+@compound CO2
+@compound N2
+
 include("landscape.jl")   
 include("interpolation.jl")
 include("fluid_properties.jl")

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -11,10 +11,10 @@ function sinec!(
     TSR = TMIN
     TREF = (TIMTMX - TIMSR) / 2 + TIMSR
     SS = 360.0 * (TIMSS - TREF) / (2.0 * (TIMTMX - TIMSR))
-    SY = SS / 57.29577
+    SY = SS / 57.29577 # TODO what is 57.29577
     ZS = sin(SY)
     TSS = A * ZS + TMIN + A
-    TAU = 3.0 / ((2400.0 - TIMSS) + TIMSR)
+    TAU = 3.0 / ((2400.0 - TIMSS) + TIMSR) # TODO What is 3.0 and 2400
 
     for I in 1:24
         J = I + 1
@@ -215,7 +215,7 @@ function hourly_vars(
         #     TIME OF AIR TEMPERATURE MINIMUM (NOTE: A KLUGE OF 200, I.E. 2
         #     HOURS IS BEING USED TO MAKE SINEC WORK WHEN MORNING MINIMUM
         #     IS NOT AT TRUE SUNRISE, THE ALGORITHM IS 2 HOURS OFF FOR SOME
-        #     UNKNOWN (6/7/89) REASON)
+        #     UNKNOWN (6/7/89) REASON) TODO: fix this 36 year old bug or delete the comment
         if TIMINS[1] > 0
             TSRHR = TIMINS[1] + 2.0
         else


### PR DESCRIPTION
This PR is just exploring the scope of the kinds of cleanup we need to do.

- We have hundreds of constants as numbers (directly in the code without explanation) that need to be a set of `const` global variables. Probably we should use PhysicalConstants.jl for many of the common ones. https://github.com/JuliaPhysics/PhysicalConstants.jl

- We have a lot of `ustrip(x)` which is very dangerous, and possibly worse than not having units! We need to do `ustrip(target_units, x)`.
- There are a lot of * 1000, / 1000 s in the code. Unitful should do all of this for us.
- Since we can return NamedTuple we should start using good readable variable names that are consistent throughout the package, and lock them down with calls like `(; some, variable, names) = a_function(args...)`

I'm keen to blitz the whole codebase with these changes - but I will certainly make a few mistakes doing that, it will be many hundreds, probably thousands of lines. Currently these kind of changes are a little stressful to do. We need to get code coverage up very high so we know most (even all) of the lines are hit by tests and any mistakes will be caught. Then these kind of changes can be done in a relaxed way going forward.
