### PR TITLE
fix heights and rename short variables

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -94,9 +94,8 @@ function runmicro(;
     latitude = 43.07305u"°", # latitude
     days = [15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349], # days of year to simulate - TODO leap years
     hours = collect(0.:1:24.), # hour of day for solrad
-    reference_height = 2u"m", # reference height of weather data (air temperature, wind speed, humidity)
     depths = [0.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 100.0, 200.0]u"cm", # soil nodes - keep spacing close near the surface
-    heights = [0.01]u"m", # air nodes for temperature, wind speed and humidity profile
+    heights = [0.01, 2]u"m", # air nodes for temperature, wind speed and humidity profile, last height is reference height for weather data
     # solar radiation
     cmH2O = 1, # precipitable cm H2O in air column, 0.1 = very dry; 1 = moist air conditions; 2 = humid, tropical conditions (note this is for the whole atmospheric profile, not just near the ground)
     ϵ = 0.0167238, # orbital eccentricity of Earth
@@ -187,6 +186,7 @@ function runmicro(;
     __n::Val{N} = Val{length(depths)}() # This is a tiny hack so N is known to the compiler in function body
 ) where N
 
+    reference_height = last(heights)
     ndays = length(days)
     # defining view factor for sky radiation based on horizon angles
     viewfactor = 1 - sum(sin.(horizon_angles)) / length(horizon_angles) # convert horizon angles to radians and calc view factor(s)
@@ -372,8 +372,8 @@ function runmicro(;
 
     # simulate all days
     pool = 0.0u"kg/m^2" # initialise depth of pooling water TODO make this an init option
-    heights_water_balance = [0.01] .* u"m" # for evaporation calculation TODO how sensitive ot this height?
-    soil_water_balance_buffers = allocate_soil_water_balance(numnodes_b, heights_water_balance, reference_height)  # only once
+    heights_water_balance = [0.01, reference_height] .* u"m" # for evaporation calculation TODO how sensitive to this height?
+    soil_water_balance_buffers = allocate_soil_water_balance(numnodes_b)  # only once
     niter_moist = ustrip(3600 / moist_step) # TODO use a solver for soil moisture calc
     ∑phase = zeros(Float64, numnodes_a)u"J"
     infil_out = nothing
@@ -482,7 +482,7 @@ function runmicro(;
                                 RHs = humidities,
                                 ZENRs = zenith_angles,
                                 T0,
-                                heights=heights_water_balance,
+                                heights = heights_water_balance,
                                 elevation,
                                 pool,
                                 θ_soil0_b,
@@ -634,7 +634,6 @@ function runmicro(;
     profile_out = map(1:length(air_temperatures)) do i
         # compute scalar profiles
         get_profile(;
-            reference_height,
             z0 = roughness_height,
             zh,
             d0,
@@ -660,13 +659,13 @@ function runmicro(;
         relative_humidity,
         # TODO just use the same names in the code above 
         # all these name conversions are unnecesary
-        cloud_cover=cloud_covers,
+        cloud_cover = cloud_covers,
         global_solar,
         direct_solar,
         diffuse_solar,
         zenith_angle = zenith_angles,
         sky_temperature = T_skys,
-        soil_temperature = T_soils,
+        soil_temperature = reduce(vcat, transpose.(T_soils)),
         soil_moisture = θ_soils,
         soil_water_potential = ψ_soils,
         soil_humidity = rh_soils,

--- a/src/soil_balance.jl
+++ b/src/soil_balance.jl
@@ -79,7 +79,6 @@ function soil_energy_balance(
 
     # Convection
     profile_out = get_profile(;
-        reference_height,
         z0 = roughness_height, 
         d0 = d0, 
         zh = zh, 
@@ -87,7 +86,7 @@ function soil_energy_balance(
         TAREF = u"°C"(tair), 
         VREF = vel, 
         ZEN = zenr, 
-        heights = [0.01] .* u"m", 
+        heights = [0.01u"m", reference_height], 
         rh, 
         elevation
     )
@@ -158,7 +157,7 @@ function evap(; tsurf, tair, rh, rhsurf, hd, elevation, pctwet, sat)
     return qevap, gwsurf
 end
 
-function allocate_soil_water_balance(M, heights, reference_height)
+function allocate_soil_water_balance(M)
     (;
         P = zeros(M+1) .* u"J/kg",
         Z = zeros(M+1) .* u"m",
@@ -195,7 +194,6 @@ function allocate_soil_water_balance(M, heights, reference_height)
         P_out = Vector{typeof(1.0u"J/kg")}(undef, M),
         H_out = Vector{Float64}(undef, M),
         PR_out = Vector{typeof(1.0u"J/kg")}(undef, M),
-        # profile = allocate_profile(heights, reference_height),
     )  
 end
 
@@ -442,7 +440,6 @@ end
 get_soil_water_balance(; M=18, kw...) = get_soil_water_balance!(allocate_soil_water_balance(M); M, kw...)
 
 function get_soil_water_balance!(buffers;
-    reference_height,
     roughness_height,
     zh,
     d0,
@@ -479,7 +476,6 @@ function get_soil_water_balance!(buffers;
 )
     # compute scalar profiles
     profile_out = get_profile(;
-        reference_height,
         z0=roughness_height,
         zh,
         d0,

--- a/test/micro_testrun_daily.jl
+++ b/test/micro_testrun_daily.jl
@@ -30,7 +30,7 @@ microinput = (; zip(names, microinput_vec)...)
 days = collect(1:Int(length(soil_temperature_nmr[:, 1]) / 24)) # days of year to run (for solrad)
 depths = ((DataFrame(CSV.File("$testdir/data/init_daily/DEP.csv"))[:, 2]) / 100.0)u"m" # Soil nodes (cm) - keep spacing close near the surface, last value is where it is assumed that the soil temperature is at the annual mean air temperature
 heights = [0.01]u"m" # air nodes for temperature, wind speed and humidity profile
-days2do = 30
+days2do = 365
 hours2do = days2do * 24
 # now try the simulation function
 keywords = (;

--- a/test/micro_testrun_monthly.jl
+++ b/test/micro_testrun_monthly.jl
@@ -29,14 +29,13 @@ longlat = (DataFrame(CSV.File("$testdir/data/init_monthly/longlat.csv"))[:, 2] *
 days = [15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349]
 LAIs = fill(0.1, length(days))
 depths = ((DataFrame(CSV.File("$testdir/data/init_monthly/DEP.csv"))[:, 2]) / 100.0)u"m"
-heights = [0.01]u"m" # air nodes for temperature, wind speed and humidity profile
+heights = [0.01, microinput[:Refhyt]]u"m" # air nodes for temperature, wind speed and humidity profile
 
 keywords = (;
     # locations, times, depths and heights
     latitude = longlat[2]*1.0u"°",
     days, # days of year for solrad
     hours = hours = collect(0.:1:24.), # hour of day for solrad
-    reference_height = microinput[:Refhyt] * 1.0u"m",
     depths,
     heights, # air nodes for temperature, wind speed and humidity profile
     # terrain


### PR DESCRIPTION
This PR changes heights vector to include reference height at the end and stabilise the length of the vector from the start, fix output of soil temperatures, as well as cosmetic variable name changes for better readability of code (cherry-picked from a past branch)