### PR TITLE
fix type stability of get_longwave

### DIFF
--- a/src/radiation.jl
+++ b/src/radiation.jl
@@ -1592,13 +1592,14 @@ function get_longwave(;
     # Atmospheric radiation
     if swinbank
         # Swinbank, Eq. 10.11 in Campbell and Norman 1998
-        arad = ((9.2e-6 * (u"K"(tair))^2) * σ * (u"K"(tair))^4) / 1u"K^2" 
+        arad = uconvert(u"W*m^-2", ((9.2e-6 * (u"K"(tair))^2) * σ * (u"K"(tair))^4) / 1u"K^2")
     else
         # Campbell and Norman 1998 eq. 10.10 to get emissivity of sky
         P_vap = wet_air_out.P_vap
         # TODO: ustrip to what
-        arad = u"W/m^2"(ustrip(1.72 * (ustrip(u"kPa"(P_vap)) / ustrip(u"K"(tair) + 0.01u"K"))^(1//7)) * σ * (u"K"(tair) + 0.01u"K")^4) 
+        arad = u"W/m^2"((1.72 * (ustrip(u"kPa", P_vap) / ustrip(u"K", tair + 0.01u"K"))^(1//7)) * σ * (u"K"(tair) + 0.01u"K")^4) 
     end
+
     # Cloud radiation temperature (shade approximation, TAIR - 2°C)
     crad = σ * slep * (u"K"(tair) - 2.0u"K")^4
 


### PR DESCRIPTION
Where we have units calculated in a branch we need to force them to be the same for type stability