### PR TITLE
Reduce allocations in `get_profile`

### DIFF
--- a/src/boundary_layer.jl
+++ b/src/boundary_layer.jl
@@ -441,7 +441,6 @@ function calc_Obukhov_length(T_ref_height, T_surface, v_ref_height, z0, z, ρcpT
     T_ref_height = u"K"(T_ref_height)
     T_surface = u"K"(T_surface)
     v_ref_height = u"cm/minute"(v_ref_height)
-
     # initialise
     Q_convection = nothing
     effective_stanton_number = nothing
@@ -449,9 +448,10 @@ function calc_Obukhov_length(T_ref_height, T_surface, v_ref_height, z0, z, ρcpT
     sublayer_stanton_number = nothing
     u_star = nothing
     ψ_h = nothing
-    φ_m = nothing
     δ = 1.0
     count = 0
+    φ_m = nothing
+    L_Obukhov_new = nothing
 
     while δ > tol && count < max_iter
         count += 1
@@ -466,19 +466,7 @@ function calc_Obukhov_length(T_ref_height, T_surface, v_ref_height, z0, z, ρcpT
         δ = abs((L_Obukhov_new - L_Obukhov) / L_Obukhov)
         L_Obukhov = L_Obukhov_new
     end
-
-    # TODO comment this or make it a function
     T_z0 = (T_ref_height * bulk_stanton_number + T_surface * sublayer_stanton_number) / (bulk_stanton_number + sublayer_stanton_number)
-
-    return (; 
-        L_Obukhov=u"m"(L_Obukhov), 
-        sublayer_stanton_number, 
-        effective_stanton_number, 
-        bulk_stanton_number, 
-        u_star, 
-        ψ_h, 
-        Q_convection, 
-        T_z0,
-    )
+    return (; L_Obukhov=u"m"(L_Obukhov), sublayer_stanton_number, effective_stanton_number, bulk_stanton_number, u_star, ψ_h, Q_convection, T_z0)
 end
 

--- a/src/soil_balance.jl
+++ b/src/soil_balance.jl
@@ -478,8 +478,8 @@ function get_soil_water_balance!(buffers;
     M=18,
 )
     # compute scalar profiles
-    profile_out = get_profile(;
-        z0 = roughness_height,
+    profile_out = get_profile!(buffers.profile;
+        roughness_height,
         zh,
         d0,
         κ,
@@ -488,7 +488,6 @@ function get_soil_water_balance!(buffers;
         relative_humidity = RHs[step],
         surface_temperature = u"°C"(T0[1]),  # top layer temp
         zenith_angle = ZENRs[step],
-        heights,
         elevation,
         P_atmos,
     )
@@ -511,7 +510,7 @@ function get_soil_water_balance!(buffers;
         θ_soil0_b[1] = 1 - BD[1] / DD[1]
     end
     # run infiltration algorithm
-    infil_out = soil_water_balance!(buffers;
+    infil_out = soil_water_balance!(buffers.soil_water_balance;
         PE, KS, BB, BD, DD, rh_loc, elevation, P_atmos, L, rw, pc, rl, sp, r1, lai, im, moist_count, M, 
         θ_soil=θ_soil0_b,
         ET=EP,
@@ -527,7 +526,7 @@ function get_soil_water_balance!(buffers;
         θ_soil0_b[1] = 1 - BD[1] / DD[1]
     end
     for _ in 1:(niter_moist-1)
-        infil_out = soil_water_balance!(buffers;
+        infil_out = soil_water_balance!(buffers.soil_water_balance;
             PE, KS, BB, BD, DD, elevation, P_atmos, L, rw, pc, rl, sp, r1, lai, im, moist_count, rh_loc,
             θ_soil=θ_soil0_b,
             ET=EP,


### PR DESCRIPTION
This PR removes allocations in `get_profile` by preallocating buffers and using `get_profile!` instead