### PR TITLE
Find_uninitialised_variables

### DIFF
--- a/src/landscape.jl
+++ b/src/landscape.jl
@@ -57,7 +57,7 @@ function MicroResult(nsteps::Int, numnodes_a::Int)
         global_solar = Array{typeof(1.0u"W/m^2")}(undef, nsteps),
         direct_solar = Array{typeof(1.0u"W/m^2")}(undef, nsteps),
         diffuse_solar = Array{typeof(1.0u"W/m^2")}(undef, nsteps),
-        zenith_angle = Array{Float64}(undef, nsteps),
+        zenith_angle = Array{typeof(1.0u"°")}(undef, nsteps),
         sky_temperature = Array{typeof(1.0u"K")}(undef, nsteps),
         soil_temperature = Array{typeof(1.0u"K")}(undef, nsteps, numnodes_a),
         soil_moisture = Array{Float64}(undef, nsteps, numnodes_a),

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -265,6 +265,7 @@ function interpolate_minmax!(output, environment_minmax, environment_daily, envi
     output.reference_temperature .= reference_temperature
     output.reference_wind_speed .= reference_wind_speed
     output.reference_humidity .= reference_humidity
+    output.zenith_angle .= solrad_out.zenith_angle
 
     return 
 end
@@ -273,6 +274,7 @@ function interpolate_minmax!(output, environment_minmax::Nothing, environment_da
     output.reference_temperature .= environment_hourly.reference_temperature
     output.reference_wind_speed .= environment_hourly.reference_wind_speed
     output.reference_humidity .= environment_hourly.reference_humidity
+    output.zenith_angle .= solrad_out.zenith_angle
 
     return 
 end
@@ -302,7 +304,7 @@ function solve_soil!(output::MicroResult, mp::MicroProblem, solrad_out;
 )
     (; terrain, soil_thermal_model, soil_moisture_model, environment_minmax, environment_daily, daily, initial_soil_temperature, initial_soil_moisture, runmoist, hourly_rainfall) = mp
     (; moist_step, Campbells_b_parameter, soil_bulk_density2, soil_mineral_density2, air_entry_water_potential) = soil_moisture_model
-    
+
     ndays = length(days)
     nhours = length(hours)
     numnodes_a = length(depths) # number of soil nodes for temperature calcs and final output


### PR DESCRIPTION
Found the culprit - zenith_angle wasn't defined for output, which was causing instabilities with the conditional check in atmospheric_surface_profile! for unstable conditions