### PR TITLE
update snow tests to new structure

### DIFF
--- a/test/micro_testrun_monthly_snow.jl
+++ b/test/micro_testrun_monthly_snow.jl
@@ -36,39 +36,29 @@ days2do = 1:12
 
 precomputed_soil_moisture = (Array(DataFrame(CSV.File("$testdir/data/init_monthly/moists.csv"))[:, 2:13]) .* 1.0)
 
-#TODO make one terrain object via BiophysicalEcologyBase or BiophysicalGrids
-#TODO make P_atmos time a varying input
-micro_terrain = MicroTerrain(;
-    elevation = microinput[:ALTT] * 1.0u"m", # elevation (m)
-    roughness_height = microinput[:RUF] * 1.0u"m", # roughness height for standard mode TODO dispatch based on roughness pars
-    karman_constant = 0.4, # Kármán constant
-    dyer_constant = 16.0, # coefficient from Dyer and Hicks for Φ_m (momentum), γ
-    viewfactor = 1.0, # view factor to sky
+site = Site(;
+    latitude = longlat[2] * 1.0u"°",
+    longitude = longlat[1] * 1.0u"°",
+    elevation = microinput[:ALTT] * 1.0u"m",
+    slope = microinput[:slope] * 1.0u"°",
+    aspect = microinput[:azmuth] * 1.0u"°",
+    horizon_angles = (DataFrame(CSV.File("$testdir/data/init_monthly_snow/hori.csv"))[:, 2]) * 1.0u"°",
+    sky_view_fraction = 1.0,
+    albedo = DataFrame(CSV.File("$testdir/data/init_monthly_snow/REFLS.csv"))[1, 2] * 1.0,
+    roughness_height = microinput[:RUF] * 1.0u"m",
+    atmospheric_pressure = atmospheric_pressure(microinput[:ALTT] * 1.0u"m"),
 )
-
-solar_terrain = SolarTerrain(;
-    slope = (microinput[:slope])*1.0u"°",
-    aspect = (microinput[:azmuth])*1.0u"°",
-    elevation = (microinput[:ALTT])*1.0u"m",
-    horizon_angles = (DataFrame(CSV.File("$testdir/data/init_monthly_snow/hori.csv"))[:, 2])*1.0u"°",
-    albedo = (DataFrame(CSV.File("$testdir/data/init_monthly_snow/REFLS.csv"))[1, 2] * 1.0),
-    atmospheric_pressure = atmospheric_pressure((microinput[:ALTT])*1.0u"m"),
-    latitude = longlat[2]*1.0u"°",
-    longitude = longlat[1]*1.0u"°",
-)
+boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 
 mineral_density = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][6]) * 1.0u"Mg/m^3" # soil minerals density (Mg/m3)
 bulk_density = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][2]) * 1.0u"Mg/m^3" # dry soil bulk density (Mg/m3)
 
-soil_thermal_model = CampbelldeVriesSoilThermal(;
-    bulk_density, 
-    mineral_density,
-    de_vries_shape_factor = 0.1, # de Vries shape factor, 0.33 for organic soils, 0.1 for mineral
-    mineral_conductivity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K", # soil minerals thermal conductivity (W/mC)
-    mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K", # soil minerals specific heat (J/kg-K)
-    saturation_moisture = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][3]) * 1.0u"m^3/m^3", # volumetric water content at saturation (0.1 bar matric potential) (m3/m3)
-    recirculation_power = 4.0, # power for recirculation function
-    return_flow_threshold = 0.162, # return-flow cutoff soil moisture, m^3/m^3
+soil_thermal = CampbelldeVriesSoilThermal(;
+    de_vries_shape_factor = 0.1,
+    mineral_conductivity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K",
+    mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K",
+    recirculation_power = 4.0,
+    return_flow_threshold = 0.162,
 )
 
 rainfall = (DataFrame(CSV.File("$testdir/data/init_monthly_snow/rain.csv"))[days2do, 2] * 1.0)u"kg/m^2"
@@ -110,18 +100,17 @@ environment_minmax = MonthlyMinMaxEnvironment(;
 )
 
 _runmoist = Bool(Int(microinput[:runmoist]))
-soil_moisture_model = example_soil_hydraulics(depths; bulk_density, mineral_density,
-    root_density = fill(0.0, length(depths))u"m/m^3",
-    mode = _runmoist ? DynamicSoilMoisture() : PrescribedSoilMoisture(; precomputed_soil_moisture))
-solar_model = SolarProblem(; scattered_uv = Bool(Int(microinput[:IUV])))
+soil_hydraulics = example_soil_hydraulics(depths; bulk_density, mineral_density,
+    root_density = fill(0.0, length(depths))u"m/m^3")
+solar_model = SolarProblem(;
+    diffuse_model = Bool(Int(microinput[:IUV])) ? SolarRadiation.ChandrasekharScattering() : SolarRadiation.NoScattering(),
+)
 
 # Set up time mode from the daily/spinup flags
 _daily = Bool(Int(microinput[:microdaily]))
 _spinup = Bool(Int(microinput[:spinup]))
-time_mode = _daily ? ConsecutiveDayMode(; spinup_first_day=_spinup) : NonConsecutiveDayMode(; ndmax=Int(microinput[:ndmax]))
-
-# Set up convergence strategy
-convergence = FixedSoilTemperatureIterations(Int(microinput[:ndmax]))
+time_mode = _daily ? ConsecutiveDayMode(; spinup_first_day=_spinup) :
+    NonConsecutiveDayMode(; iterations_per_day=Int(microinput[:ndmax]))
 
 snow_model = SnowModel(;
     snow_temperature_threshold = microinput[:snowtemp] * u"°C",
@@ -135,28 +124,30 @@ snow_model = SnowModel(;
     canopy_interception = microinput[:intercept],
 )
 
+config = MicroConfig(;
+    boundary_layer_model,
+    time_mode,
+    convergence = FixedSoilTemperatureIterations(Int(microinput[:ndmax])),
+    rainfall_schedule = Bool(Int(microinput[:rainhourly])) ? HourlyRainfall() : DailyRainfall(),
+    soil_moisture_strategy = _runmoist ? DynamicSoilMoisture() : PrescribedSoilMoisture(; precomputed_soil_moisture),
+)
+
 # now try the simulation function
 problem = MicroProblem(;
     # locations, times, depths and heights
-    latitude = longlat[2]*1.0u"°",
     days = days[days2do], # days of year for solar_radiation
     hours = collect(0.0:1:23.0), # hour of day for solar_radiation
     depths,
     heights, # air nodes for temperature, wind speed and humidity profile
     # Objects defined above
     solar_model,
-    solar_terrain,
-    snow_model,
-    micro_terrain, #TODO combine terrains via a generic terrain in BiophysicalEcologyBase
-    soil_moisture_model,
-    soil_thermal_model,
+    site,
+    parameters = MicroParameters(; soil_thermal, soil_hydraulics, snow=snow_model),
     environment_minmax,
     environment_daily,
     environment_hourly,
-    time_mode,
-    convergence,
-    hourly_rainfall = Bool(Int(microinput[:rainhourly])),
-    # intial conditions
+    config,
+    # initial conditions
     initial_soil_temperature = nothing,
     initial_soil_moisture = precomputed_soil_moisture[1:10, 1],
 )
@@ -164,7 +155,11 @@ problem = MicroProblem(;
 @time micro_out = Microclimate.solve(problem);
 
 # subset NicheMapR predictions
+vel1cm_nmr = collect(metout_nmr[:, 8]) .* 1u"m/s"
 vel2m_nmr = collect(metout_nmr[:, 9]) .* 1u"m/s"
+ta1cm_nmr = collect(metout_nmr[:, 4] .+ 273.15) .* 1u"K"
+ta2m_nmr = collect(metout_nmr[:, 5] .+ 273.15) .* 1u"K"
+rh1cm_nmr = collect(metout_nmr[:, 6]) ./ 100.0
 rh2m_nmr = collect(metout_nmr[:, 7]) ./ 100.0
 tskyC_nmr = collect(metout_nmr[:, 15]) .* u"°C"
 solr_nmr = collect(metout_nmr[:, 14]) .* u"W/m^2"
@@ -194,7 +189,8 @@ snow_valid = .!ismissing.(snowdepth_nmr)
 end
 
 # Visual comparisons — run manually (not in CI)
-# using Plots
+#=
+using Plots
 let
     t = 1:length(days2do)*24
     depth_labels = ["$(round(ustrip(u"cm", depths[i]); digits=1)) cm" for i in 1:length(depths)]
@@ -227,3 +223,4 @@ let
     plot!(p_atm, t, snowdensity_nmr[t];                                  sp=8, label="NicheMapR", color=:black)
     display(p_atm)
 end
+=#

--- a/test/micro_testrun_snow_scan329.jl
+++ b/test/micro_testrun_snow_scan329.jl
@@ -87,45 +87,36 @@ forcing = DataFrame(CSV.File(joinpath(datadir, "forcing.csv")))
 days2do = 1:NDAYS
 
 # ── Terrain ───────────────────────────────────────────────────────────────────
-micro_terrain = MicroTerrain(;
-    elevation      = ELEVATION,
-    roughness_height = RUF,
-    karman_constant  = 0.4,
-    dyer_constant    = 16.0,
-    viewfactor       = 1.0,
-)
-
-solar_terrain = SolarTerrain(;
-    slope              = 0.0u"°",
-    aspect             = 0.0u"°",
-    elevation          = ELEVATION,
-    horizon_angles     = zeros(24)u"°",
-    albedo             = ALBEDO,
-    atmospheric_pressure = atmospheric_pressure(ELEVATION),
+site = Site(;
     latitude           = LATITUDE,
     longitude          = LONGITUDE,
+    elevation          = ELEVATION,
+    slope              = 0.0u"°",
+    aspect             = 0.0u"°",
+    horizon_angles     = zeros(24)u"°",
+    sky_view_fraction  = 1.0,
+    albedo             = ALBEDO,
+    roughness_height   = RUF,
+    atmospheric_pressure = atmospheric_pressure(ELEVATION),
 )
+boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 
 # ── Soil models ───────────────────────────────────────────────────────────────
-soil_thermal_model = CampbelldeVriesSoilThermal(;
-    bulk_density          = BULK_DENSITY,
-    mineral_density       = MINERAL_DENSITY,
+soil_thermal = CampbelldeVriesSoilThermal(;
     de_vries_shape_factor = DE_VRIES_SHAPE_FACTOR,
     mineral_conductivity  = MINERAL_CONDUCTIVITY,
     mineral_heat_capacity = MINERAL_HEAT_CAPACITY,
-    saturation_moisture   = SATURATION_MOISTURE,
     recirculation_power   = 4.0,
     return_flow_threshold = 0.162,
 )
 
-soil_moisture_model = example_soil_hydraulics(DEPTHS;
+soil_hydraulics = example_soil_hydraulics(DEPTHS;
     bulk_density                     = BULK_DENSITY,
     mineral_density                  = MINERAL_DENSITY,
     air_entry_water_potential        = fill(AIR_ENTRY_POTENTIAL, length(DEPTHS)),
     saturated_hydraulic_conductivity = fill(SAT_HYDRAULIC_COND, length(DEPTHS)),
     campbell_b_parameter             = fill(CAMPBELL_B, length(DEPTHS)),
     root_density                     = ROOT_DENSITY,
-    mode                             = DynamicSoilMoisture(),
 )
 
 # ── Daily min/max environment (1461 days) ─────────────────────────────────────
@@ -167,7 +158,7 @@ environment_hourly = HourlyTimeseries(;
     longwave_radiation    = nothing,
 )
 
-solar_model = SolarProblem(; scattered_uv = false)
+solar_model = SolarProblem(; diffuse_model = SolarRadiation.NoScattering())
 
 snow_model = SnowModel(;
     snow_temperature_threshold = 1.5u"°C",
@@ -182,24 +173,26 @@ snow_model = SnowModel(;
 )
 
 # ── Build and solve ───────────────────────────────────────────────────────────
+config = MicroConfig(;
+    boundary_layer_model,
+    time_mode             = ConsecutiveDayMode(; spinup_first_day=false),
+    convergence           = FixedSoilTemperatureIterations(3),
+    rainfall_schedule     = DailyRainfall(),
+    soil_moisture_strategy = DynamicSoilMoisture(),
+)
+
 problem = MicroProblem(;
-    latitude              = LATITUDE,
     days                  = forcing.DOY[days2do],
     hours                 = collect(0.0:1:23.0),
     depths                = DEPTHS,
     heights               = [USRHYT, REFHYT],
     solar_model,
-    solar_terrain,
-    micro_terrain,
-    soil_moisture_model,
-    soil_thermal_model,
+    site,
+    parameters            = MicroParameters(; soil_thermal, soil_hydraulics, snow=snow_model),
     environment_minmax,
     environment_daily,
     environment_hourly,
-    time_mode             = ConsecutiveDayMode(; spinup_first_day=false),
-    convergence           = FixedSoilTemperatureIterations(3),
-    hourly_rainfall       = false,
-    snow_model,
+    config,
     initial_soil_temperature = INITIAL_ST,
     initial_soil_moisture = Vector{Float64}(INITIAL_SM),
     #initial_snow_depth = 78.0u"cm",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,4 +11,5 @@ using Microclimate, Test, SafeTestsets
 # Tests
 @safetestset "example constructors" begin include("example_constructors.jl") end
 @safetestset "monthly simulation" begin include("micro_testrun_monthly.jl") end
+@safetestset "monthly snow simulation" begin include("micro_testrun_monthly_snow.jl") end
 @safetestset "daily simulation" begin include("micro_testrun_daily.jl") end


### PR DESCRIPTION
This PR updates the two snow tests to the new structure of the model inputs and adds the monthly (non-consecutive days) snow test to runtests.jl script. 

The monthly snow test currently fails but PR #102 resolves this for the version with the old structure so once #102 is merged it should pass.