### PR TITLE
refactor of SoilProfile

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -373,7 +373,7 @@ function solve_soil!(cache::MicroCache)
     time_mode = mp.time_mode
     moisture_mode = config.soil_moisture_strategy
     (; campbell_b_parameter, air_entry_water_potential) = soil_profile.hydraulics
-    (; bulk_density, mineral_density) = soil_profile
+    (; bulk_density, mineral_density, mineral_conductivity, mineral_heat_capacity) = soil_profile
     init_soil_wetness!(moisture_mode)
 
     ndays = length(days)
@@ -416,6 +416,7 @@ function solve_soil!(cache::MicroCache)
     end
     update_soil_properties!(output, soil_prop_view, soil_properties_model;
         soil_temperature=T0, soil_moisture, bulk_density, mineral_density,
+        mineral_conductivity, mineral_heat_capacity,
         atmospheric_pressure=101325.0u"Pa", step=1
     )
 
@@ -574,6 +575,7 @@ function solve_soil!(cache::MicroCache)
                 output.sky_temperature[day_init_step] = longwave_sky.sky_temperature
                 update_soil_properties!(output, soil_prop_view, soil_properties_model;
                     soil_temperature=T0, soil_moisture, bulk_density, mineral_density,
+                    mineral_conductivity, mineral_heat_capacity,
                     atmospheric_pressure=output.pressure[day_init_step],
                     step=day_init_step, vapour_pressure_equation,
                 )
@@ -784,6 +786,7 @@ function solve_soil!(cache::MicroCache)
                     environment_instant = get_instant(environment_day, environment_hourly, output, soil_moisture, output_step)
                     update_soil_properties!(output, soil_prop_view, soil_properties_model;
                         soil_temperature=T0, soil_moisture, bulk_density, mineral_density,
+                        mineral_conductivity, mineral_heat_capacity,
                         atmospheric_pressure=environment_instant.atmospheric_pressure, step=output_step, vapour_pressure_equation
                     )
                 end

--- a/src/snow/snow_model.jl
+++ b/src/snow/snow_model.jl
@@ -649,6 +649,7 @@ end
         soil_temperature=soil_temp_soil,
         soil_moisture=p.soil_moisture,
         bulk_density=p.soil_profile.bulk_density, mineral_density=p.soil_profile.mineral_density,
+        mineral_conductivity=p.soil_profile.mineral_conductivity, mineral_heat_capacity=p.soil_profile.mineral_heat_capacity,
         atmospheric_pressure, vapour_pressure_equation,
     )
     soil_temp_snow = SVector(ntuple(k -> soil_temperature[k], Val(N_snow)))

--- a/src/soil_balance/energy/heat_transport_1d.jl
+++ b/src/soil_balance/energy/heat_transport_1d.jl
@@ -111,6 +111,7 @@ end
     soil_properties!(p.buffers.soil_properties, p.soil_properties_model;
         soil_temperature, soil_moisture=p.soil_moisture,
         bulk_density=p.soil_profile.bulk_density, mineral_density=p.soil_profile.mineral_density,
+        mineral_conductivity=p.soil_profile.mineral_conductivity, mineral_heat_capacity=p.soil_profile.mineral_heat_capacity,
         atmospheric_pressure, vapour_pressure_equation,
     )
     return nothing

--- a/src/soil_properties/abstract.jl
+++ b/src/soil_properties/abstract.jl
@@ -1,7 +1,7 @@
 abstract type AbstractSoilProperties end
 
 """
-    soil_properties(soil_properties_model; atmospheric_pressure, soil_temperature, soil_moisture, bulk_density, mineral_density, vapour_pressure_equation)
+    soil_properties(soil_properties_model; atmospheric_pressure, soil_temperature, soil_moisture, bulk_density, mineral_density, mineral_conductivity, mineral_heat_capacity, vapour_pressure_equation)
 
 Scalar bulk-property computation for one soil layer. Every variant must
 accept the listed kwargs and return
@@ -18,6 +18,8 @@ function soil_properties!(buffers::NamedTuple, soil_properties_model::AbstractSo
     atmospheric_pressure::Quantity, soil_temperature::AbstractVector, soil_moisture::AbstractVector,
     bulk_density::AbstractVector,
     mineral_density::AbstractVector,
+    mineral_conductivity::AbstractVector,
+    mineral_heat_capacity::AbstractVector,
     vapour_pressure_equation=GoffGratch(),
 )
     num_layers = length(soil_temperature)
@@ -32,6 +34,8 @@ function soil_properties!(buffers::NamedTuple, soil_properties_model::AbstractSo
             soil_moisture = soil_moisture[i],
             bulk_density = bulk_density[i],
             mineral_density = mineral_density[i],
+            mineral_conductivity = mineral_conductivity[i],
+            mineral_heat_capacity = mineral_heat_capacity[i],
             vapour_pressure_equation,
         )
         bulk_thermal_conductivity[i] = result.bulk_thermal_conductivity

--- a/src/soil_properties/campbell_devries.jl
+++ b/src/soil_properties/campbell_devries.jl
@@ -1,29 +1,25 @@
-# Bulk density, mineral density, and saturation moisture for the soil are
-# properties of the soil profile, not of the thermal formulation — they live on
-# the hydraulics model and are passed into `soil_properties` as kwargs.
-@kwdef struct CampbelldeVriesSoilProperties{SF,MC,MHC,RP,RFT} <: AbstractSoilProperties
+# Bulk density, mineral density, mineral conductivity, mineral heat capacity,
+# and saturation moisture for the soil are properties of the soil profile, not
+# of the thermal formulation — they live on the hydraulics model / soil
+# profile and are passed into `soil_properties` as kwargs.
+@kwdef struct CampbelldeVriesSoilProperties{SF,RP,RFT} <: AbstractSoilProperties
     de_vries_shape_factor::SF
-    mineral_conductivity::MC
-    mineral_heat_capacity::MHC
     recirculation_power::RP
     return_flow_threshold::RFT
 end
 
 function example_soil_properties_model(;
     de_vries_shape_factor = 0.1, # de Vries shape factor, 0.33 for organic soils, 0.1 for mineral
-    mineral_conductivity = 1.25u"W/m/K", # soil minerals thermal conductivity
-    mineral_heat_capacity = 870.0u"J/kg/K", # soil minerals specific heat
     recirculation_power = 4.0, # power for recirculation function
     return_flow_threshold = 0.162, # return-flow cutoff soil moisture, m^3/m^3
 )
     CampbelldeVriesSoilProperties(;
-        de_vries_shape_factor, mineral_conductivity, mineral_heat_capacity,
-        recirculation_power, return_flow_threshold,
+        de_vries_shape_factor, recirculation_power, return_flow_threshold,
     )
 end
 
 """
-    soil_properties(soil_properties_model; atmospheric_pressure, soil_temperature, soil_moisture, bulk_density, mineral_density)
+    soil_properties(soil_properties_model; atmospheric_pressure, soil_temperature, soil_moisture, bulk_density, mineral_density, mineral_conductivity, mineral_heat_capacity)
 
 Compute bulk soil properties — thermal conductivity, volumetric heat capacity,
 and bulk density — for a given soil layer.
@@ -37,8 +33,10 @@ and bulk density — for a given soil layer.
 - `atmospheric_pressure::Quantity`: Atmospheric pressure.
 - `soil_temperature::Quantity`: Soil temperature in Kelvin.
 - `soil_moisture::Real`: Volumetric soil moisture (m³/m³).
-- `bulk_density::Quantity`: Dry soil bulk density (kg/m³). Owned by the soil hydraulics model.
-- `mineral_density::Quantity`: Soil mineral density (kg/m³). Owned by the soil hydraulics model.
+- `bulk_density::Quantity`: Dry soil bulk density (kg/m³). Owned by `SoilProfile`.
+- `mineral_density::Quantity`: Soil mineral density (kg/m³). Owned by `SoilProfile`.
+- `mineral_conductivity::Quantity`: Soil mineral thermal conductivity (W/m/K). Owned by `SoilProfile`.
+- `mineral_heat_capacity::Quantity`: Soil mineral specific heat (J/kg/K). Owned by `SoilProfile`.
 
 # Returns
 
@@ -84,10 +82,11 @@ function soil_properties(soil_properties_model::CampbelldeVriesSoilProperties;
     soil_moisture::Number,
     bulk_density::Quantity,
     mineral_density::Quantity,
+    mineral_conductivity::Quantity,
+    mineral_heat_capacity::Quantity,
     vapour_pressure_equation=GoffGratch(),
 )
-    (; mineral_conductivity, mineral_heat_capacity,
-       recirculation_power, return_flow_threshold, de_vries_shape_factor) = soil_properties_model
+    (; recirculation_power, return_flow_threshold, de_vries_shape_factor) = soil_properties_model
 
     standard_pressure = Unitful.atm
     shape_factor_c = 1.0 - 2.0 * de_vries_shape_factor

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,28 +1,36 @@
 """
-    SoilProfile(; bulk_density, mineral_density, hydraulics)
+    SoilProfile(; bulk_density, mineral_density, mineral_conductivity, mineral_heat_capacity, hydraulics)
 
 Per-depth soil column profile read by the soil properties model (thermal)
 and the soil hydraulic model. Sized to match `MicroModel.depths`.
 
 - `bulk_density` — dry soil bulk density (kg/m³) at each depth node
 - `mineral_density` — soil mineral density (kg/m³) at each depth node
+- `mineral_conductivity` — soil mineral thermal conductivity (W/m/K) at each depth node
+- `mineral_heat_capacity` — soil mineral specific heat (J/kg/K) at each depth node
 - `hydraulics` — per-depth hydraulic parameters (e.g. `CampbellHydraulicProfile`)
   matched to the chosen `soil_hydraulic_model`
 """
-@kwdef struct SoilProfile{BD,MD,H}
+@kwdef struct SoilProfile{BD,MD,MC,MHC,H}
     bulk_density::BD
     mineral_density::MD
+    mineral_conductivity::MC
+    mineral_heat_capacity::MHC
     hydraulics::H
 end
 
 function example_soil_profile(depths=DEFAULT_DEPTHS;
     bulk_density = 1.3u"Mg/m^3",
     mineral_density = 2.560u"Mg/m^3",
+    mineral_conductivity = 1.25u"W/m/K",
+    mineral_heat_capacity = 870.0u"J/kg/K",
     hydraulics = example_campbell_hydraulic_profile(depths),
 )
     SoilProfile(;
         bulk_density = bulk_density isa AbstractVector ? bulk_density : fill(bulk_density, length(depths)),
         mineral_density = mineral_density isa AbstractVector ? mineral_density : fill(mineral_density, length(depths)),
+        mineral_conductivity = mineral_conductivity isa AbstractVector ? mineral_conductivity : fill(mineral_conductivity, length(depths)),
+        mineral_heat_capacity = mineral_heat_capacity isa AbstractVector ? mineral_heat_capacity : fill(mineral_heat_capacity, length(depths)),
         hydraulics,
     )
 end
@@ -122,10 +130,11 @@ Per-run input data: site, soil column profile, environment forcings, and
 initial conditions.
 
 - `site::Site` — properties of the place
-- `soil_profile::SoilProfile` — per-depth `bulk_density` and `mineral_density`
-  read by both the soil properties and soil hydraulic models. Per-location
-  structural soil-column data; lives here (not on `MicroModel`) because it
-  varies between sites without changing the physics.
+- `soil_profile::SoilProfile` — per-depth `bulk_density`, `mineral_density`,
+  `mineral_conductivity`, and `mineral_heat_capacity` read by both the soil
+  properties and soil hydraulic models. Per-location structural soil-column
+  data; lives here (not on `MicroModel`) because it varies between sites
+  without changing the physics.
 - `environment_minmax`, `environment_daily`, `environment_hourly` — input forcings
 - `initial_*` — initial conditions (`initial_soil_temperature=nothing` falls back to
   the day-mean reference air temperature)

--- a/test/micro_testrun_daily.jl
+++ b/test/micro_testrun_daily.jl
@@ -56,10 +56,11 @@ site = Site(;
 )
 boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 
+mineral_conductivity = (CSV.File("$testdir/data/init_daily/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K" # soil minerals thermal conductivity (W/mC)
+mineral_heat_capacity = (CSV.File("$testdir/data/init_daily/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K" # soil minerals specific heat (J/kg-K)
+
 soil_properties_model = CampbelldeVriesSoilProperties(;
     de_vries_shape_factor = 0.1, # de Vries shape factor, 0.33 for organic soils, 0.1 for mineral
-    mineral_conductivity = (CSV.File("$testdir/data/init_daily/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K", # soil minerals thermal conductivity (W/mC)
-    mineral_heat_capacity = (CSV.File("$testdir/data/init_daily/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K", # soil minerals specific heat (J/kg-K)
     recirculation_power = 4.0, # power for recirculation function
     return_flow_threshold = 0.162, # return-flow cutoff soil moisture, m^3/m^3
 )
@@ -82,6 +83,8 @@ _runmoist = Bool(Int(microinput[:runmoist]))
 soil_profile = SoilProfile(;
     bulk_density = (DataFrame(CSV.File("$testdir/data/init_daily/BD.csv"))[:, 2] * 1.0u"Mg/m^3"),
     mineral_density = (DataFrame(CSV.File("$testdir/data/init_daily/DD.csv"))[:, 2] * 1.0u"Mg/m^3"),
+    mineral_conductivity = fill(mineral_conductivity, length(depths)),
+    mineral_heat_capacity = fill(mineral_heat_capacity, length(depths)),
     hydraulics = CampbellHydraulicProfile(;
         air_entry_water_potential = (DataFrame(CSV.File("$testdir/data/init_daily/PE.csv"))[:, 2] * 1.0u"J/kg"),
         saturated_hydraulic_conductivity = (DataFrame(CSV.File("$testdir/data/init_daily/KS.csv"))[:, 2] * 1.0u"kg*s/m^3"),

--- a/test/micro_testrun_monthly.jl
+++ b/test/micro_testrun_monthly.jl
@@ -54,10 +54,11 @@ boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 mineral_density = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][6]) * 1.0u"Mg/m^3" # soil minerals density (Mg/m3)
 bulk_density = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][2]) * 1.0u"Mg/m^3" # dry soil bulk density (Mg/m3)
 
+mineral_conductivity = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K" # soil minerals thermal conductivity (W/mC)
+mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K" # soil minerals specific heat (J/kg-K)
+
 soil_properties_model = CampbelldeVriesSoilProperties(;
     de_vries_shape_factor = 0.1, # de Vries shape factor, 0.33 for organic soils, 0.1 for mineral
-    mineral_conductivity = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K", # soil minerals thermal conductivity (W/mC)
-    mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K", # soil minerals specific heat (J/kg-K)
     recirculation_power = 4.0, # power for recirculation function
     return_flow_threshold = 0.162, # return-flow cutoff soil moisture, m^3/m^3
 )
@@ -102,6 +103,8 @@ _runmoist = Bool(Int(microinput[:runmoist]))
 soil_profile = SoilProfile(;
     bulk_density = fill(bulk_density, length(depths)),
     mineral_density = fill(mineral_density, length(depths)),
+    mineral_conductivity = fill(mineral_conductivity, length(depths)),
+    mineral_heat_capacity = fill(mineral_heat_capacity, length(depths)),
     hydraulics = example_campbell_hydraulic_profile(depths;
         root_density = fill(0.0, length(depths))u"m/m^3"),
 )

--- a/test/micro_testrun_monthly_snow.jl
+++ b/test/micro_testrun_monthly_snow.jl
@@ -53,10 +53,11 @@ boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 mineral_density = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][6]) * 1.0u"Mg/m^3" # soil minerals density (Mg/m3)
 bulk_density = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][2]) * 1.0u"Mg/m^3" # dry soil bulk density (Mg/m3)
 
+mineral_conductivity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K" # soil minerals thermal conductivity (W/mC)
+mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K" # soil minerals specific heat (J/kg-K)
+
 soil_properties_model = CampbelldeVriesSoilProperties(;
     de_vries_shape_factor = 0.1, # de Vries shape factor, 0.33 for organic soils, 0.1 for mineral
-    mineral_conductivity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][4]) * 1.0u"W/m/K", # soil minerals thermal conductivity (W/mC)
-    mineral_heat_capacity = (CSV.File("$testdir/data/init_monthly_snow/soilprop.csv")[1, 1][5]) * 1.0u"J/kg/K", # soil minerals specific heat (J/kg-K)
     recirculation_power = 4.0, # power for recirculation function
     return_flow_threshold = 0.162, # return-flow cutoff soil moisture, m^3/m^3
 )
@@ -103,6 +104,8 @@ _runmoist = Bool(Int(microinput[:runmoist]))
 soil_profile = SoilProfile(;
     bulk_density = fill(bulk_density, length(depths)),
     mineral_density = fill(mineral_density, length(depths)),
+    mineral_conductivity = fill(mineral_conductivity, length(depths)),
+    mineral_heat_capacity = fill(mineral_heat_capacity, length(depths)),
     hydraulics = example_campbell_hydraulic_profile(depths;
         root_density = fill(0.0, length(depths))u"m/m^3"),
 )

--- a/test/micro_testrun_snow_scan329.jl
+++ b/test/micro_testrun_snow_scan329.jl
@@ -130,15 +130,15 @@ boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 # ── Soil models ───────────────────────────────────────────────────────────────
 soil_properties_model = CampbelldeVriesSoilProperties(;
     de_vries_shape_factor = DE_VRIES_SHAPE_FACTOR,
-    mineral_conductivity  = MINERAL_CONDUCTIVITY,
-    mineral_heat_capacity = MINERAL_HEAT_CAPACITY,
     recirculation_power   = 4.0,
     return_flow_threshold = 0.162,
 )
 
 soil_profile = SoilProfile(;
-    bulk_density    = fill(BULK_DENSITY, length(DEPTHS)),
-    mineral_density = fill(MINERAL_DENSITY, length(DEPTHS)),
+    bulk_density          = fill(BULK_DENSITY, length(DEPTHS)),
+    mineral_density       = fill(MINERAL_DENSITY, length(DEPTHS)),
+    mineral_conductivity  = fill(MINERAL_CONDUCTIVITY, length(DEPTHS)),
+    mineral_heat_capacity = fill(MINERAL_HEAT_CAPACITY, length(DEPTHS)),
     hydraulics      = CampbellHydraulicProfile(;
         air_entry_water_potential        = fill(AIR_ENTRY_POTENTIAL, length(DEPTHS)),
         saturated_hydraulic_conductivity = fill(SAT_HYDRAULIC_COND, length(DEPTHS)),

--- a/test/snow_obs_comparison.jl
+++ b/test/snow_obs_comparison.jl
@@ -98,15 +98,15 @@ boundary_layer_model = MoninObukhov(; karman_constant=0.4, dyer_constant=16.0)
 # ── Soil models ──────────────────────────────────────────────────────────────
 soil_properties_model = CampbelldeVriesSoilProperties(;
     de_vries_shape_factor = DE_VRIES_SHAPE_FACTOR,
-    mineral_conductivity  = MINERAL_CONDUCTIVITY,
-    mineral_heat_capacity = MINERAL_HEAT_CAPACITY,
     recirculation_power   = 4.0,
     return_flow_threshold = 0.162,
 )
 
 soil_profile = SoilProfile(;
-    bulk_density    = fill(BULK_DENSITY, length(DEPTHS)),
-    mineral_density = fill(MINERAL_DENSITY, length(DEPTHS)),
+    bulk_density          = fill(BULK_DENSITY, length(DEPTHS)),
+    mineral_density       = fill(MINERAL_DENSITY, length(DEPTHS)),
+    mineral_conductivity  = fill(MINERAL_CONDUCTIVITY, length(DEPTHS)),
+    mineral_heat_capacity = fill(MINERAL_HEAT_CAPACITY, length(DEPTHS)),
     hydraulics      = CampbellHydraulicProfile(;
         air_entry_water_potential        = fill(AIR_ENTRY_POTENTIAL, length(DEPTHS)),
         saturated_hydraulic_conductivity = fill(SAT_HYDRAULIC_COND, length(DEPTHS)),


### PR DESCRIPTION
move mineral_conductivity and mineral_heat_capacity from CampbelldeVriesSoilProperties to SoilProfile - they more naturally belong there as depth-varying parameters