### PR TITLE
Add lateral surface-water inflow and runoff output (routing support)

### DIFF
--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -15,7 +15,7 @@ function AtmosphericProfile(nsteps::Int, nheights::Int)
     )
 end
 
-@kwdef struct MicroResult{P,AT,WS,RH,CC,GS,DF,SkT,SoT,SM,SWP,SH,STC,SPH,SBD,SW,SR,Pr,SF,SD,SDN,SNT}
+@kwdef struct MicroResult{P,AT,WS,RH,CC,GS,DF,SkT,SoT,SM,SWP,SH,STC,SPH,SBD,SW,RG,SR,Pr,SF,SD,SDN,SNT}
     pressure::P
     reference_temperature::AT
     reference_wind_speed::WS
@@ -32,6 +32,10 @@ end
     soil_heat_capacity::SPH
     soil_bulk_density::SBD
     surface_water::SW
+    # Surface water (kg/m^2) shed laterally per output step — the overflow above
+    # `max_surface_pool` that would otherwise be discarded by the pool clamp.
+    # A spatial driver routes this downslope along a topographic flow graph.
+    runoff_generated::RG
     solar_radiation::SR
     profile::Pr
     snow_fall::SF
@@ -57,6 +61,7 @@ function MicroResult(nsteps::Int, num_nodes::Int, nheights::Int, solar_radiation
         soil_heat_capacity = Array{typeof(1.0u"J/kg/K")}(undef, nsteps, num_nodes),
         soil_bulk_density = Array{typeof(1.0u"kg/m^3")}(undef, nsteps, num_nodes),
         surface_water = Array{typeof(1.0u"kg/m^2")}(undef, nsteps),
+        runoff_generated = zeros(typeof(1.0u"kg/m^2"), nsteps),
         solar_radiation = solar_radiation,
         profile = AtmosphericProfile(nsteps, nheights),
         snow_fall = zeros(typeof(1.0u"cm/hr"), nsteps),

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -364,7 +364,8 @@ function solve_soil!(cache::MicroCache)
     soil_freezing_model = soil_energy_model.freezing_model
     (; site, soil_profile, environment_daily, environment_hourly,
        initial_soil_temperature, initial_soil_moisture,
-       initial_snow_depth, initial_snow_temperature, initial_snow_density) = mp.inputs
+       initial_snow_depth, initial_snow_temperature, initial_snow_density,
+       lateral_inflow) = mp.inputs
     n_snow = n_snow_nodes(snow_model)
     soil_moisture = cache.state.soil_moisture
     ∑phase = cache.state.∑phase
@@ -376,6 +377,8 @@ function solve_soil!(cache::MicroCache)
     forcing = cache.forcing
 
     (; convergence, rainfall_schedule, max_surface_pool) = config
+    # Per-site override (e.g. a very large pool for endorheic sink cells).
+    max_surface_pool = something(mp.inputs.max_surface_pool, max_surface_pool)
     time_mode = mp.time_mode
     moisture_mode = config.soil_moisture_strategy
     (; campbell_b_parameter, air_entry_water_potential) = soil_profile.hydraulics
@@ -762,13 +765,21 @@ function solve_soil!(cache::MicroCache)
                     snow_temp_threshold = n_snow > 0 ? snow_model.snow_temperature_threshold : 0.0u"°C"
                     melted_water = n_snow > 0 ? uconvert(u"kg/m^2", thermal_melt * 1.0u"g/cm^3") : 0.0u"kg/m^2"
                     rain_melt_water = n_snow > 0 ? uconvert(u"kg/m^2", rain_melt_snow * snow_state.density) : 0.0u"kg/m^2"
+                    # Lateral surface water routed in from upslope cells (0 when uncoupled).
+                    # Aligned with `output.surface_water[step + 1]` (= output_step below).
+                    lateral_in = _lateral_inflow_at(lateral_inflow, step + 1)
                     if snow_present && u"°C"(environment_instant.reference_temperature) < snow_temp_threshold
                         # Cold snow: rain absorbed into snowpack (handled in update_snow! as snowfall); only thermal melt enters pool
-                        pool = clamp(pool + melted_water, 0.0u"kg/m^2", max_surface_pool)
+                        pool_supply = pool + melted_water + lateral_in
                     else
-                        # Warm snow or no snow: rain + rain_melt water + thermal melt enter pool
-                        pool = clamp(pool + rain + rain_melt_water + melted_water, 0.0u"kg/m^2", max_surface_pool)
+                        # Warm snow or no snow: rain + rain_melt water + thermal melt + lateral inflow enter pool
+                        pool_supply = pool + rain + rain_melt_water + melted_water + lateral_in
                     end
+                    pool = clamp(pool_supply, 0.0u"kg/m^2", max_surface_pool)
+                    # Surface water in excess of the pool's holding capacity is shed
+                    # laterally (routed downslope by a spatial driver). Previously the
+                    # clamp discarded this water; now it is conserved as an output.
+                    runoff_generated = max(pool_supply - max_surface_pool, 0.0u"kg/m^2")
                     # Soil moisture physics; output write happens below at output_step
                     (; pool, soil_moisture, infil_out) = step_soil_moisture!(moisture_mode, buffers, soil_hydraulic_model;
                         soil_profile, depths, site, boundary_layer_model, environment_instant, T0, pool, soil_moisture,
@@ -786,6 +797,7 @@ function solve_soil!(cache::MicroCache)
                 write_output = is_last_iter && in_bounds && !next_day_resets
                 if write_output
                     output.surface_water[output_step] = pool
+                    output.runoff_generated[output_step] = runoff_generated
                     _write_row!(output.soil_temperature, output_step, T0_output)
                     output.sky_temperature[output_step] = longwave_sky.sky_temperature
                     update_soil_water!(output, soil_moisture, infil_out, output_step)
@@ -1047,6 +1059,12 @@ end
 # dispatch on that first, then _maybe_indexed handles the field-level case.
 @inline _maybe_hourly_longwave(::Nothing, _) = nothing
 @inline _maybe_hourly_longwave(environment_hourly, i) = _maybe_indexed(environment_hourly.longwave_radiation, i)
+
+# Lateral surface-water inflow (kg/m^2) for output row `i`. `nothing` (uncoupled)
+# or an out-of-range index yields zero, so the pool update stays valid on the
+# final row where `output_step = step + 1` can point one past the last stored step.
+@inline _lateral_inflow_at(::Nothing, _) = 0.0u"kg/m^2"
+@inline _lateral_inflow_at(v, i) = (1 <= i <= length(v)) ? v[i] : 0.0u"kg/m^2"
 
 function get_instant(environment_day, environment_hourly, output, soil_moisture, i)
     return (;

--- a/src/types.jl
+++ b/src/types.jl
@@ -139,11 +139,22 @@ initial conditions.
 - `initial_*` — initial conditions (`initial_soil_temperature=nothing` falls back to
   the day-mean reference air temperature)
 - `initial_snow_density=nothing` → use `model.snow_model.snow_density`
+- `lateral_inflow=nothing` — optional per-output-step surface water (`kg/m^2`)
+  arriving laterally from upslope cells, added to the surface pool each hour.
+  A vector of length `nsteps = ndays * nhours` (one entry per output row,
+  aligned with `output.surface_water`), or `nothing` for no lateral coupling.
+  Set by a spatial driver that routes water along a topographic flow graph;
+  the inner solver stays column-local and just consumes it as a forcing.
+- `max_surface_pool=nothing` — optional per-site override of
+  `config.max_surface_pool` (`kg/m^2`). A spatial driver sets this very large
+  for endorheic sink cells so routed inflow accumulates and is removed only by
+  evaporation/infiltration (an emergent lake) rather than being shed. `nothing`
+  uses the model-level `config.max_surface_pool`.
 
 Pass a fresh `MicroInputs` to `reinit!(cache, inputs)` to re-solve the same
 model on different data without rebuilding the cache.
 """
-@kwdef struct MicroInputs{S,SP<:SoilProfile,EMM,EH,ED,IST,ISM,ISD,ISNT,ISND}
+@kwdef struct MicroInputs{S,SP<:SoilProfile,EMM,EH,ED,IST,ISM,ISD,ISNT,ISND,LI,MSP}
     site::S
     soil_profile::SP
     environment_minmax::EMM
@@ -154,6 +165,8 @@ model on different data without rebuilding the cache.
     initial_snow_depth::ISD = 0.0u"cm"
     initial_snow_temperature::ISNT = u"K"(0.0u"°C")
     initial_snow_density::ISND = nothing
+    lateral_inflow::LI = nothing
+    max_surface_pool::MSP = nothing
 end
 
 """


### PR DESCRIPTION
Add `lateral_inflow` and `max_surface_pool` to `MicroInputs`, feed lateral inflow into the surface-pool water balance, and expose per-output-step `runoff_generated` (the overflow above `max_surface_pool`) on `MicroResult`.

Lets a spatial driver route surface water between columns along a flow graph while the inner solve stays column-local and consumes inflow as a forcing.